### PR TITLE
Avoid potential self-comparison warnings [-Wtautological-compare]

### DIFF
--- a/example_implementation/gtest-regular.h
+++ b/example_implementation/gtest-regular.h
@@ -157,9 +157,15 @@ class RegularTypeChecker {
   template <unsigned example_index>
   bool CheckEqualToSelf() const {
     const Example& example = GetExample<example_index>();
-    const T& value = example.GetValue();
-    if (value == value) {
-      if (!(value != value)) {
+
+    // `if (value == value)` might cause a compile warning ("self-comparison
+    // always evaluates to true [-Wtautological-compare]"), so instead,
+    // use two different references to the same object.
+    const T& left_operand = example.GetValue();
+    const T& right_operand = example.GetValue();
+
+    if (left_operand == right_operand) {
+      if (!(left_operand != right_operand)) {
         return true;
       }
       message_.append("Object should not compare unequal to itself!");


### PR DESCRIPTION
Avoid GCC/Clang warning: self-comparison always evaluates to true [-Wtautological-compare]

Note that such a warning does not seem to appear inside a class template, for the compilers currently on the CI. It did on clang 3.0 to 3.3, though: https://godbolt.org/z/bcvF46