### PR TITLE
Avoid -Wfloat-equal, -Wtautological-compare by Equal, Unequal functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(${PROJECT_NAME} gtest)
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX)
 else()
-  target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -pedantic -Werror)
+  target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -pedantic -Werror -Wfloat-equal)
 endif()
 
 add_test(NAME hello_gtest_regular_test COMMAND ${PROJECT_NAME})

--- a/expect_regular_test.cc
+++ b/expect_regular_test.cc
@@ -323,7 +323,9 @@ GTEST_TEST(TestRegular, IrregularSelfMoveAssignment) {
     }
 
     bool operator==(const IrregularType& arg) const {
-      return data_ == arg.data_;
+      // Do not do "data_ == arg.data_", to avoid a warning like "comparing
+      // floating point with == or != is unsafe [-Wfloat-equal]".
+      return (data_ <= arg.data_) && (data_ >= arg.data_);
     }
     bool operator!=(const IrregularType& arg) const { return !(*this == arg); }
 


### PR DESCRIPTION
Use private static helper functions `RegularTypeChecker::Equal`, `RegularTypeChecker::Unequal`, instead of using `==` and `!=` directly, to avoid:

  "self-comparison always evaluates to true [-Wtautological-compare]"
  "comparing floating point with == or != is unsafe [-Wfloat-equal]"